### PR TITLE
Bbduk ASCII parameter

### DIFF
--- a/clean.nf
+++ b/clean.nf
@@ -385,7 +385,7 @@ def helpMSG() {
     ${c_green}--rm_rrna ${c_reset}      clean your data from rRNA [default: $params.rm_rrna]
     ${c_green}--bbduk${c_reset}         add this flag to use bbduk instead of minimap2 for decontamination of short reads [default: $params.bbduk]
     ${c_green}--bbduk_kmer${c_reset}    set kmer for bbduk [default: $params.bbduk_kmer]
-    ${c_green}--bbduk_qin${c_reset}     set quality ASCII encoding for bbduk [default: $params.bbduk_qin]
+    ${c_green}--bbduk_qin${c_reset}     set quality ASCII encoding for bbduk [default: $params.bbduk_qin; options are: 64, 33, auto]
     ${c_green}--reads_rna${c_reset}           add this flag for noisy direct RNA-Seq Nanopore data [default: $params.reads_rna]
 
     ${c_yellow}Compute options:${c_reset}

--- a/clean.nf
+++ b/clean.nf
@@ -385,6 +385,7 @@ def helpMSG() {
     ${c_green}--rm_rrna ${c_reset}      clean your data from rRNA [default: $params.rm_rrna]
     ${c_green}--bbduk${c_reset}         add this flag to use bbduk instead of minimap2 for decontamination of short reads [default: $params.bbduk]
     ${c_green}--bbduk_kmer${c_reset}    set kmer for bbduk [default: $params.bbduk_kmer]
+    ${c_green}--bbduk_qin${c_reset}     set quality ASCII encoding for bbduk [default: $params.bbduk_qin]
     ${c_green}--reads_rna${c_reset}           add this flag for noisy direct RNA-Seq Nanopore data [default: $params.reads_rna]
 
     ${c_yellow}Compute options:${c_reset}

--- a/modules/bbmap.nf
+++ b/modules/bbmap.nf
@@ -43,7 +43,7 @@ process bbduk {
   
   # bbduk
   MEM=\$(echo ${task.memory} | sed 's/ GB//g')
-  bbduk.sh -Xmx\${MEM}g ref=${db} threads=${task.cpus} stats=bbduk_stats.txt ordered=t k=${params.bbduk_kmer} in=${name}.R1.id.fastq in2=${name}.R2.id.fastq out=${name}.clean.R1.id.fastq out2=${name}.clean.R2.id.fastq outm=${name}.contamination.R1.id.fastq outm2=${name}.contamination.R2.id.fastq
+  bbduk.sh -Xmx\${MEM}g ref=${db} threads=${task.cpus} stats=bbduk_stats.txt ordered=t k=${params.bbduk_kmer} qin=${params.bbduk_qin} in=${name}.R1.id.fastq in2=${name}.R2.id.fastq out=${name}.clean.R1.id.fastq out2=${name}.clean.R2.id.fastq outm=${name}.contamination.R1.id.fastq outm2=${name}.contamination.R2.id.fastq
 
   # restore the original read IDs
   sed 's/DECONTAMINATE/ /g' ${name}.clean.R1.id.fastq | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/1"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}.clean.R1.fastq.gz 
@@ -63,7 +63,7 @@ process bbduk {
   
   # bbduk
   MEM=\$(echo ${task.memory} | sed 's/ GB//g')
-  bbduk.sh -Xmx\${MEM}g ref=${db} threads=${task.cpus} stats=bbduk_stats.txt ordered=t k=${params.bbduk_kmer} in=${name}.id.fastq out=${name}.clean.id.fastq outm=${name}.contamination.id.fastq
+  bbduk.sh -Xmx\${MEM}g ref=${db} threads=${task.cpus} stats=bbduk_stats.txt ordered=t k=${params.bbduk_kmer} qin=${params.bbduk_qin} in=${name}.id.fastq out=${name}.clean.id.fastq outm=${name}.contamination.id.fastq
 
   sed 's/DECONTAMINATE/ /g' ${name}.clean.id.fastq | pigz -p ${task.cpus} > ${name}.clean.fastq.gz
   sed 's/DECONTAMINATE/ /g' ${name}.contamination.id.fastq | pigz -p ${task.cpus} > ${name}.contamination.fastq.gz

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,7 +25,7 @@ params {
   rm_rrna = false
   bbduk = false
   bbduk_kmer = 27
-  bbduk_qin = 64
+  bbduk_qin = 'auto'
   reads_rna = false
 
   // folder structure

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,6 +25,7 @@ params {
   rm_rrna = false
   bbduk = false
   bbduk_kmer = 27
+  bbduk_qin = 64
   reads_rna = false
 
   // folder structure


### PR DESCRIPTION
fixes #26 

I added a parameter to control the PHRED ASCII scoring used with `BBduk`. The default is `auto` but can be changed now. 

To make this more stable could need some check that only {auto, 64, 33} are allowed values for this parameter. 

And in general a `additional_params_bbduk` might make sense bc/ the tool can be actually configured in many ways and we don't want to mirror all the params. 