### PR TITLE
Fixes #19, filter minimap2 stats, kinda fixes #25

### DIFF
--- a/modules/bbmap.nf
+++ b/modules/bbmap.nf
@@ -1,8 +1,6 @@
 process bbduk {
   label 'bbmap'
   
-  publishDir "${params.output}/${name}/bbduk", mode: 'copy', pattern: "*.gz"
-
   input:
   tuple val(name), path(reads)
   path db
@@ -10,65 +8,20 @@ process bbduk {
 
   output:
   val name, emit: name
-  tuple val(name), path('*clean*.fastq.gz')
-  tuple val(name), path('*contamination*.fastq.gz')
+  tuple val(name), val('clean'), path('*clean.fastq'), emit: cleaned_reads
+  tuple val(name), val('contamination'), path('*contamination.fastq'), emit: contaminated_reads
   path 'bbduk_stats.txt', emit: stats
 
   script:
   if ( mode == 'paired' ) {
   """
-  # replace the space in the header to retain the full read IDs after mapping (the mapper would split the ID otherwise after the first space)
-  # this is working for ENA reads that have at the end of a read id '/1' or '/2'
-  EXAMPLE_ID=\$(zcat ${reads[0]} | head -1)
-  if [[ \$EXAMPLE_ID == */1 ]]; then 
-    if [[ ${reads[0]} =~ \\.gz\$ ]]; then
-      zcat ${reads[0]} | sed 's/ /DECONTAMINATE/g' > ${name}.R1.id.fastq
-    else
-      sed 's/ /DECONTAMINATE/g' ${reads[0]} > ${name}.R1.id.fastq
-    fi
-    if [[ ${reads[1]} =~ \\.gz\$ ]]; then
-      zcat ${reads[1]} | sed 's/ /DECONTAMINATE/g' > ${name}.R2.id.fastq
-    else
-      sed 's/ /DECONTAMINATE/g' ${reads[1]} > ${name}.R2.id.fastq
-    fi
-  else
-    # this is for paried-end SRA reads that don't follow the ENA pattern
-    if [[ ${reads[0]} =~ \\.gz\$ ]]; then
-      zcat ${reads[0]} > ${name}.R1.id.fastq
-      zcat ${reads[1]} > ${name}.R2.id.fastq
-    else
-      mv ${reads[0]} ${name}.R1.id.fastq
-      mv ${reads[1]} ${name}.R2.id.fastq
-    fi
-  fi
-  
-  # bbduk
-  MEM=\$(echo ${task.memory} | sed 's/ GB//g')
-  bbduk.sh -Xmx\${MEM}g ref=${db} threads=${task.cpus} stats=bbduk_stats.txt ordered=t k=${params.bbduk_kmer} in=${name}.R1.id.fastq in2=${name}.R2.id.fastq out=${name}.clean.R1.id.fastq out2=${name}.clean.R2.id.fastq outm=${name}.contamination.R1.id.fastq outm2=${name}.contamination.R2.id.fastq
-
-  # restore the original read IDs
-  sed 's/DECONTAMINATE/ /g' ${name}.clean.R1.id.fastq | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/1"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}.clean.R1.fastq.gz 
-  sed 's/DECONTAMINATE/ /g' ${name}.clean.R2.id.fastq | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/2"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}.clean.R2.fastq.gz
-  sed 's/DECONTAMINATE/ /g' ${name}.contamination.R1.id.fastq | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/1"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}.contamination.R1.fastq.gz 
-  sed 's/DECONTAMINATE/ /g' ${name}.contamination.R2.id.fastq | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/2"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}.contamination.R2.fastq.gz
-  rm -f ${name}.R1.id.fastq ${name}.R2.id.fastq ${name}.clean.R1.id.fastq ${name}.clean.R2.id.fastq ${name}.contamination.R1.id.fastq ${name}.contamination.R2.id.fastq
+    MEM=\$(echo ${task.memory} | sed 's/ GB//g')
+    bbduk.sh -Xmx\${MEM}g ref=${db} threads=${task.cpus} stats=bbduk_stats.txt ordered=t k=${params.bbduk_kmer} in=${reads[0]} in2=${reads[1]} out=${reads[0].baseName}.clean.fastq out2=${reads[1].baseName}.clean.fastq outm=${reads[0].baseName}.contamination.fastq outm2=${reads[1].baseName}.contamination.fastq
   """
   } else {
-  """
-  # remove spaces in read IDs to keep them in the later cleaned output
-  if [[ ${reads} =~ \\.gz\$ ]]; then
-    zcat ${reads} | sed 's/ /DECONTAMINATE/g' > ${name}.id.fastq
-  else
-    sed 's/ /DECONTAMINATE/g' ${reads} > ${name}.id.fastq
-  fi
-  
-  # bbduk
-  MEM=\$(echo ${task.memory} | sed 's/ GB//g')
-  bbduk.sh -Xmx\${MEM}g ref=${db} threads=${task.cpus} stats=bbduk_stats.txt ordered=t k=${params.bbduk_kmer} in=${name}.id.fastq out=${name}.clean.id.fastq outm=${name}.contamination.id.fastq
-
-  sed 's/DECONTAMINATE/ /g' ${name}.clean.id.fastq | pigz -p ${task.cpus} > ${name}.clean.fastq.gz
-  sed 's/DECONTAMINATE/ /g' ${name}.contamination.id.fastq | pigz -p ${task.cpus} > ${name}.contamination.fastq.gz
-  rm -f ${name}.clean.id.fastq ${name}.contamination.id.fastq
-  """
+    """
+    MEM=\$(echo ${task.memory} | sed 's/ GB//g')
+    bbduk.sh -Xmx\${MEM}g ref=${db} threads=${task.cpus} stats=bbduk_stats.txt ordered=t k=${params.bbduk_kmer} in=${reads} out=${reads.baseName}.clean.fastq outm=${reads.baseName}.contamination.fastq
+    """
   }
 }

--- a/modules/minimap2.nf
+++ b/modules/minimap2.nf
@@ -17,14 +17,14 @@ process minimap2_fasta {
     path '*.contamination.sorted.bam'
     path '*.contamination.sorted.bam.bai'
     path 'idxstats.tsv', emit: idxstats
-    env TOTALREADS, emit: totalreads
+    env TOTALCONTIGS, emit: totalcontigs
 
   script:
   """
   if [[ ${fasta} =~ \\.gz\$ ]]; then
-    TOTALREADS=\$(zgrep '^>' ${fasta} | wc -l)
+    TOTALCONTIGS=\$(zgrep '^>' ${fasta} | wc -l)
   else
-    TOTALREADS=\$(grep '^>' ${fasta} | wc -l)
+    TOTALCONTIGS=\$(grep '^>' ${fasta} | wc -l)
   fi
 
   minimap2 -ax asm5 -N 5 --secondary=no -t ${task.cpus} -o ${name}.sam ${db} ${fasta}
@@ -45,60 +45,40 @@ process minimap2_fasta {
 process minimap2_nano {
   label 'minimap2'
   
-  publishDir "${params.output}/${name}/minimap2", mode: 'copy', pattern: "*.gz"
-  publishDir "${params.output}/${name}/minimap2", mode: 'copy', pattern: "*.contamination.sorted.bam"
-  publishDir "${params.output}/${name}/minimap2", mode: 'copy', pattern: "*.contamination.sorted.bam.bai"
+  publishDir "${params.output}/${name}/minimap2", mode: 'copy', pattern: "*.contamination.sorted.bam*"
 
   input: 
-    tuple val(name), path(fastq)
+    tuple val(name), path(reads)
     path db
 
   output:
-    val name, emit: name
-    path '*.gz'
-    path '*.contamination.sorted.bam'
-    path '*.contamination.sorted.bam.bai'
-    path 'idxstats.tsv', emit: idxstats
-    env TOTALREADS, emit: totalreads
+    tuple val(name), path ('idxstats.tsv'), emit: idxstats
+    tuple val(name), val('clean'), path('*clean.fastq'), emit: cleaned_reads
+    tuple val(name), val('contamination'), path('*contamination.fastq'), emit: contaminated_reads
+    path '*.contamination.sorted.bam*'
 
   script:
-  """  
-  # remove spaces in read IDs to keep them in the later cleaned output
-  if [[ ${fastq} =~ \\.gz\$ ]]; then
-    zcat ${fastq} | sed 's/ /DECONTAMINATE/g' > ${name}.id.fastq
-    TOTALREADS=\$(zcat ${fastq} | echo \$((`wc -l`/4)))
-  else
-    sed 's/ /DECONTAMINATE/g' ${fastq} > ${name}.id.fastq
-    TOTALREADS=\$(cat ${fastq} | echo \$((`wc -l`/4)))
-  fi
-
+  """
   PARAMS="-ax map-ont"
   if [[ ${params.reads_rna} != 'false' ]]; then
     PARAMS="-ax splice -k14"
   fi
 
-  minimap2 \$PARAMS -N 5 --secondary=no -t ${task.cpus} -o ${name}.sam ${db} ${name}.id.fastq
+  minimap2 \$PARAMS -N 5 --secondary=no -t ${task.cpus} -o ${name}.sam ${db} ${reads}
 
-  samtools fastq -f 4 -0 ${name}.clean.id.fastq ${name}.sam
-  samtools fastq -F 4 -0 ${name}.contamination.id.fastq ${name}.sam
-
-  sed 's/DECONTAMINATE/ /g' ${name}.clean.id.fastq | pigz -p ${task.cpus} > ${name}.clean.fastq.gz
-  sed 's/DECONTAMINATE/ /g' ${name}.contamination.id.fastq | pigz -p ${task.cpus} > ${name}.contamination.fastq.gz
+  samtools fastq -f 4 -0 ${reads.baseName}.clean.fastq ${name}.sam
+  samtools fastq -F 4 -0 ${reads.baseName}.contamination.fastq ${name}.sam
 
   samtools view -b -F 2052 ${name}.sam | samtools sort -o ${name}.contamination.sorted.bam --threads ${task.cpus}
   samtools index ${name}.contamination.sorted.bam
   samtools idxstats  ${name}.contamination.sorted.bam > idxstats.tsv
-
-  rm -f ${name}.sam ${name}.clean.id.fastq ${name}.contamination.id.fastq
   """
 }
 
 process minimap2_illumina {
   label 'minimap2'
 
-  publishDir "${params.output}/${name}/minimap2", mode: 'copy', pattern: "*.gz"
-  publishDir "${params.output}/${name}/minimap2", mode: 'copy', pattern: "*.contamination.sorted.bam"
-  publishDir "${params.output}/${name}/minimap2", mode: 'copy', pattern: "*.contamination.sorted.bam.bai"
+  publishDir "${params.output}/${name}/minimap2", mode: 'copy', pattern: "*.contamination.sorted.bam*"
 
   input: 
     tuple val(name), path(reads)
@@ -106,94 +86,34 @@ process minimap2_illumina {
     val mode
 
   output:
-    val name, emit: name
-    path '*.gz'
-    path '*.contamination.sorted.bam'
-    path '*.contamination.sorted.bam.bai'
-    path 'idxstats.tsv', emit: idxstats
-    env TOTALREADS, emit: totalreads
+    tuple val(name), path ('idxstats.tsv'), emit: idxstats
+    tuple val(name), val('clean'), path('*clean.fastq'), emit: cleaned_reads
+    tuple val(name), val('contamination'), path('*contamination.fastq'), emit: contaminated_reads
+    path '*.contamination.sorted.bam*'
 
   script:
   if ( mode == 'paired' ) {
-  """
-  # replace the space in the header to retain the full read IDs after mapping (the mapper would split the ID otherwise after the first space)
-  # this is working for ENA reads that have at the end of a read id '/1' or '/2'
-  EXAMPLE_ID=\$(zcat ${reads[0]} | head -1)
-  if [[ \$EXAMPLE_ID == */1 ]]; then 
-    if [[ ${reads[0]} =~ \\.gz\$ ]]; then
-      zcat ${reads[0]} | sed 's/ /DECONTAMINATE/g' > ${name}.R1.id.fastq
-      TOTALREADS_1=\$(zcat ${reads[0]} | echo \$((`wc -l`/4)))
-    else
-      sed 's/ /DECONTAMINATE/g' ${reads[0]} > ${name}.R1.id.fastq
-      TOTALREADS_1=\$(cat ${reads[0]} | echo \$((`wc -l`/4)))
-    fi
-    if [[ ${reads[1]} =~ \\.gz\$ ]]; then
-      zcat ${reads[1]} | sed 's/ /DECONTAMINATE/g' > ${name}.R2.id.fastq
-      TOTALREADS_2=\$(zcat ${reads[1]} | echo \$((`wc -l`/4)))
-    else
-      sed 's/ /DECONTAMINATE/g' ${reads[1]} > ${name}.R2.id.fastq
-      TOTALREADS_2=\$(cat ${reads[1]} | echo \$((`wc -l`/4)))
-    fi
-  else
-    # this is for paried-end SRA reads that don't follow the ENA pattern
-    if [[ ${reads[0]} =~ \\.gz\$ ]]; then
-      zcat ${reads[0]} > ${name}.R1.id.fastq
-      zcat ${reads[1]} > ${name}.R2.id.fastq
-      TOTALREADS_1=\$(zcat ${reads[0]} | echo \$((`wc -l`/4)))
-      TOTALREADS_2=\$(zcat ${reads[1]} | echo \$((`wc -l`/4)))
-    else
-      mv ${reads[0]} ${name}.R1.id.fastq
-      mv ${reads[1]} ${name}.R2.id.fastq
-      TOTALREADS_1=\$(cat ${reads[0]} | echo \$((`wc -l`/4)))
-      TOTALREADS_2=\$(cat ${reads[1]} | echo \$((`wc -l`/4)))
-    fi
-  fi
-  TOTALREADS=\$(( TOTALREADS_1+TOTALREADS_2 ))
+    """
+    minimap2 -ax sr -N 5 --secondary=no -t ${task.cpus} -o ${name}.sam ${db} ${reads[0]} ${reads[1]}
+    
+    # Use samtools -F 2 to discard only reads mapped in proper pair:
+    samtools fastq -F 2 -1 ${reads[0].baseName}.clean.fastq -2 ${reads[1].baseName}.clean.fastq ${name}.sam
+    samtools fastq -f 2 -1 ${reads[0].baseName}.contamination.fastq -2 ${reads[1].baseName}.contamination.fastq ${name}.sam
 
-  # Use samtools -F 2 to discard only reads mapped in proper pair:
-  minimap2 -ax sr -N 5 --secondary=no -t ${task.cpus} -o ${name}.sam ${db} ${name}.R1.id.fastq ${name}.R2.id.fastq
-  
-  samtools fastq -F 2 -1 ${name}.clean.R1.id.fastq -2 ${name}.clean.R2.id.fastq ${name}.sam
-  samtools fastq -f 2 -1 ${name}.contamination.R1.id.fastq -2 ${name}.contamination.R2.id.fastq ${name}.sam
-
-  samtools view -b -f 2 -F 2048 ${name}.sam | samtools sort -o ${name}.contamination.sorted.bam --threads ${task.cpus}
-  samtools index ${name}.contamination.sorted.bam
-  samtools idxstats ${name}.contamination.sorted.bam > idxstats.tsv
-
-  # restore the original read IDs
-  sed 's/DECONTAMINATE/ /g' ${name}.clean.R1.id.fastq | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/1"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}.clean.R1.fastq.gz 
-  sed 's/DECONTAMINATE/ /g' ${name}.clean.R2.id.fastq | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/2"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}.clean.R2.fastq.gz
-  sed 's/DECONTAMINATE/ /g' ${name}.contamination.R1.id.fastq | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/1"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}.contamination.R1.fastq.gz 
-  sed 's/DECONTAMINATE/ /g' ${name}.contamination.R2.id.fastq | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/2"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}.contamination.R2.fastq.gz
-
-  # remove intermediate files
-  rm -f ${name}.R1.id.fastq ${name}.R2.id.fastq ${name}.clean.R1.id.fastq ${name}.clean.R2.id.fastq ${name}.contamination.R1.id.fastq ${name}.contamination.R2.id.fastq ${name}.sam
-  """
+    samtools view -b -f 2 -F 2048 ${name}.sam | samtools sort -o ${name}.contamination.sorted.bam --threads ${task.cpus}
+    samtools index ${name}.contamination.sorted.bam
+    samtools idxstats ${name}.contamination.sorted.bam > idxstats.tsv
+    """
   } else {
-  """
-  # remove spaces in read IDs to keep them in the later cleaned output
-  if [[ ${reads} =~ \\.gz\$ ]]; then
-    zcat ${reads} | sed 's/ /DECONTAMINATE/g' > ${name}.id.fastq
-    TOTALREADS=\$(zcat ${reads} | echo \$((`wc -l`/4)))
-  else
-    sed 's/ /DECONTAMINATE/g' ${reads} > ${name}.id.fastq
-    TOTALREADS=\$(cat ${reads} | echo \$((`wc -l`/4)))
-  fi
+    """
+    minimap2 -ax sr -N 5 --secondary=no -t ${task.cpus} -o ${name}.sam ${db} ${reads}
+    
+    samtools fastq -f 4 -0 ${reads.baseName}.clean.fastq ${name}.sam
+    samtools fastq -F 4 -0 ${reads.baseName}.contamination.fastq ${name}.sam
 
-  minimap2 -ax sr -N 5 --secondary=no -t ${task.cpus} -o ${name}.sam ${db} ${name}.id.fastq
-  
-  samtools fastq -f 4 -0 ${name}.clean.id.fastq ${name}.sam
-  samtools fastq -F 4 -0 ${name}.contamination.id.fastq ${name}.sam
-
-  samtools view -b -F 2052 ${name}.sam | samtools sort -o ${name}.contamination.sorted.bam --threads ${task.cpus}
-  samtools index ${name}.contamination.sorted.bam
-  samtools idxstats ${name}.contamination.sorted.bam > idxstats.tsv
-
-  sed 's/DECONTAMINATE/ /g' ${name}.clean.id.fastq | pigz -p ${task.cpus} > ${name}.clean.fastq.gz
-  sed 's/DECONTAMINATE/ /g' ${name}.contamination.id.fastq | pigz -p ${task.cpus} > ${name}.contamination.fastq.gz
-
-  # remove intermediate files
-  rm -f ${name}.id.fastq ${name}.clean.id.fastq ${name}.contamination.id.fastq ${name}.sam
-  """
+    samtools view -b -F 2052 ${name}.sam | samtools sort -o ${name}.contamination.sorted.bam --threads ${task.cpus}
+    samtools index ${name}.contamination.sorted.bam
+    samtools idxstats ${name}.contamination.sorted.bam > idxstats.tsv
+    """
   }
 }

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -1,12 +1,117 @@
+process rename_reads {
+  label 'basics'
+
+  input:
+  tuple val(name), path(reads)
+  val(mode)
+
+  output:
+  tuple val(name), path("R*.fastq")
+
+  script:
+  if ( mode == 'paired' ) {
+    """
+    # replace the space in the header to retain the full read IDs after mapping (the mapper would split the ID otherwise after the first space)
+    # this is working for ENA reads that have at the end of a read id '/1' or '/2'
+    EXAMPLE_ID=\$(zcat ${reads[0]} | head -1)
+    if [[ \$EXAMPLE_ID == */1 ]]; then 
+      if [[ ${reads[0]} =~ \\.gz\$ ]]; then
+        zcat ${reads[0]} | sed 's/ /DECONTAMINATE/g' > R1.fastq
+      else
+        sed 's/ /DECONTAMINATE/g' ${reads[0]} > R1.fastq
+      fi
+      if [[ ${reads[1]} =~ \\.gz\$ ]]; then
+        zcat ${reads[1]} | sed 's/ /DECONTAMINATE/g' > R2.fastq
+      else
+        sed 's/ /DECONTAMINATE/g' ${reads[1]} > R2.fastq
+      fi
+    else
+      # this is for paried-end SRA reads that don't follow the ENA pattern
+      if [[ ${reads[0]} =~ \\.gz\$ ]]; then
+        zcat ${reads[0]} > R1.fastq
+        zcat ${reads[1]} > R2.fastq
+      else
+        mv ${reads[0]} R1.fastq
+        mv ${reads[1]} R2.fastq
+      fi
+    fi
+    """
+  } else {  
+    """
+    if [[ ${reads} =~ \\.gz\$ ]]; then
+      zcat ${reads} | sed 's/ /DECONTAMINATE/g' > R.fastq
+    else
+      sed 's/ /DECONTAMINATE/g' ${reads} > R.fastq
+    fi
+    """
+  }
+}
+
+process restore_reads {
+  label 'basics'
+
+  publishDir "${params.output}/${name}/${tool}", mode: 'copy', pattern: "*.gz"
+
+  input:
+  tuple val(name), val(type), path(reads)
+  val(mode)
+  val(tool)
+
+  output:
+  tuple val(name), path("${name}*.${type}.fastq.gz")
+
+  script:
+  if ( mode == 'paired' ) {
+    """
+    # restore the original read IDs
+    sed 's/DECONTAMINATE/ /g' ${reads}[0] | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/1"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}_1.${type}.fastq.gz 
+    sed 's/DECONTAMINATE/ /g' ${reads}[1] | awk 'BEGIN{LINE=0};{if(LINE % 4 == 0 || LINE == 0){print \$0"/2"}else{print \$0};LINE++;}' | pigz -p ${task.cpus} > ${name}_2.${type}.fastq.gz
+    """
+  } else {
+    """
+    sed 's/DECONTAMINATE/ /g' ${reads} | pigz -p ${task.cpus} > ${name}.${type}.fastq.gz
+    """
+  }
+}
+
+process get_number_of_reads {
+  input:
+  tuple val(name), path(reads)
+  val(mode)
+
+  output:
+  tuple val(name), env(TOTALREADS), emit: totalreads
+
+  script:
+  if ( mode == 'paired' ) {
+    """
+    if [[ ${reads[0]} =~ \\.gz\$ ]]; then
+      TOTALREADS_1=\$(zcat ${reads[0]} | echo \$((`wc -l`/4)))
+      TOTALREADS_2=\$(zcat ${reads[1]} | echo \$((`wc -l`/4)))
+    else
+      TOTALREADS_1=\$(cat ${reads[0]} | echo \$((`wc -l`/4)))
+      TOTALREADS_2=\$(cat ${reads[1]} | echo \$((`wc -l`/4)))
+    fi
+    TOTALREADS=\$(( TOTALREADS_1+TOTALREADS_2 ))
+    """
+  } else {
+    """
+    if [[ ${reads} =~ \\.gz\$ ]]; then
+      TOTALREADS=\$(zcat ${reads} | echo \$((`wc -l`/4)))
+    else
+      TOTALREADS=\$(cat ${reads} | echo \$((`wc -l`/4)))
+    fi
+    """
+  }
+}
+
 process minimap2Stats {
   label 'smallTask'
   
   publishDir "${params.output}/${name}/minimap2", mode: 'copy', pattern: "stats.txt" 
 
   input:
-  val name
-  val totalreads
-  path idxstats
+  tuple val(name), path(idxstats), val (totalreads)
 
   output:
   path 'stats.txt'
@@ -18,7 +123,7 @@ process minimap2Stats {
 
   MAP=\$(awk -v map=\$MAPPEDSUM -v unpromap=\$UNPROMAPPEDSUM -v tot=${totalreads} 'BEGIN {perc=(map-unpromap)/tot*100; print map-unpromap " ("  perc " %) reads were properly mapped; of these:"}')
 
-  FA=\$(awk -v tot=${totalreads} -F '\\t' '/^[^*]/ {propmap=\$3-\$4; print "\\t\\t" propmap " (" propmap/tot*100  "%) reads aligned to " \$1}' idxstats.tsv)
+  FA=\$(awk -v tot=${totalreads} -F '\\t' '/^[^*]/ {propmap=\$3-\$4; if (propmap != 0) print "\\t\\t" propmap " (" propmap/tot*100  "%) reads aligned to " \$1}' idxstats.tsv;)
 
   touch stats.txt
   cat <<EOF >> stats.txt


### PR DESCRIPTION
- modularized read renaming
- modularized  read counting
- improved minimap2 stats

If run with output read files of `CLEAN` as input, it doesn't break, but overrides the result, if `--output` is the same. I'd say it's good enough to fix #25 - but we should mention that in the readme.