### PR TITLE
Updates for cloud run

### DIFF
--- a/clean.nf
+++ b/clean.nf
@@ -450,14 +450,16 @@ workflow {
     qc_illumina(clean_illumina.out.in, clean_illumina.out.out)
     stast_illumina = clean_illumina.out.stats
     fastqc = qc_illumina.out
-  } else { fastqc = Channel.fromPath('no_illumina_input'); stast_illumina = Channel.fromPath('no_illumina_stats') }
+//  } else { fastqc = Channel.fromPath('no_illumina_input'); stast_illumina = Channel.fromPath('no_illumina_stats') } THIS FAILS IN CLOUD bc/ the cloud tries to stage a file of that name
+  } else { fastqc = Channel.empty(); stast_illumina = Channel..empty() }
 
   if (params.illumina_single_end) { 
     clean_illumina_single(illumina_single_end_input_ch, prepare_host.out.host, prepare_host.out.checkedOwn, rRNAChannel)
     qc_illumina_single(clean_illumina_single.out.in, clean_illumina_single.out.out)
     stast_illumina_single = clean_illumina_single.out.stats
     fastqc_single = qc_illumina_single.out
-  } else { fastqc_single = Channel.fromPath('no_illumina_single_input'); stast_illumina_single = Channel.fromPath('no_illumina_single_stats') }
+//  } else { fastqc_single = Channel.fromPath('no_illumina_single_input'); stast_illumina_single = Channel.fromPath('no_illumina_single_stats') }
+  } else { fastqc_single = Channel.empty(); stast_illumina_single = Channel.empty() }
 
   qc(multiqc_config, fastqc.concat(fastqc_single).collect(), nanoplot, quast, stast_fasta.concat(stast_nano).concat(stast_illumina).concat(stast_illumina_single).collect())
 }

--- a/clean.nf
+++ b/clean.nf
@@ -461,7 +461,7 @@ workflow {
 //  } else { fastqc_single = Channel.fromPath('no_illumina_single_input'); stast_illumina_single = Channel.fromPath('no_illumina_single_stats') }
   } else { fastqc_single = Channel.empty(); stast_illumina_single = Channel.empty() }
 
-  qc(multiqc_config, fastqc.concat(fastqc_single).collect(), nanoplot, quast, stast_fasta.concat(stast_nano).concat(stast_illumina).concat(stast_illumina_single).collect())
+  qc(multiqc_config, fastqc.concat(fastqc_single).collect().ifEmpty([]), nanoplot, quast, stast_fasta.concat(stast_nano).concat(stast_illumina).concat(stast_illumina_single).collect())
 }
 
 /**************************  

--- a/clean.nf
+++ b/clean.nf
@@ -436,14 +436,14 @@ workflow {
     qc_fasta(clean_fasta.out.in, clean_fasta.out.out)
     stast_fasta = clean_fasta.out.stats
     quast = qc_fasta.out.collect()
-  } else { quast = Channel.fromPath('no_fasta_input'); stast_fasta = Channel.fromPath('no_fasta_stats') }
+  } else { quast = Channel.empty(); stast_fasta = Channel.empty() }
 
   if (params.nano) { 
     clean_nano(nano_input_ch, prepare_host.out.host, prepare_host.out.checkedOwn, rRNAChannel)
     qc_nano(clean_nano.out.in, clean_nano.out.out)
     stast_nano = clean_nano.out.stats
     nanoplot = qc_nano.out.collect()
-  } else { nanoplot = Channel.fromPath('no_nanopore_input'); stast_nano = Channel.fromPath('no_nano_stats') }
+  } else { nanoplot = Channel.empty(); stast_nano = Channel.empty() }
 
   if (params.illumina) { 
     clean_illumina(illumina_input_ch, prepare_host.out.host, prepare_host.out.checkedOwn, rRNAChannel)
@@ -461,7 +461,7 @@ workflow {
 //  } else { fastqc_single = Channel.fromPath('no_illumina_single_input'); stast_illumina_single = Channel.fromPath('no_illumina_single_stats') }
   } else { fastqc_single = Channel.empty(); stast_illumina_single = Channel.empty() }
 
-  qc(multiqc_config, fastqc.concat(fastqc_single).collect().ifEmpty([]), nanoplot, quast, stast_fasta.concat(stast_nano).concat(stast_illumina).concat(stast_illumina_single).collect())
+  qc(multiqc_config, fastqc.concat(fastqc_single).collect().ifEmpty([]), nanoplot.ifEmpty([]), quast.ifEmpty([]), stast_fasta.concat(stast_nano).concat(stast_illumina).concat(stast_illumina_single).collect().ifEmpty([]))
 }
 
 /**************************  

--- a/clean.nf
+++ b/clean.nf
@@ -451,7 +451,7 @@ workflow {
     stast_illumina = clean_illumina.out.stats
     fastqc = qc_illumina.out
 //  } else { fastqc = Channel.fromPath('no_illumina_input'); stast_illumina = Channel.fromPath('no_illumina_stats') } THIS FAILS IN CLOUD bc/ the cloud tries to stage a file of that name
-  } else { fastqc = Channel.empty(); stast_illumina = Channel..empty() }
+  } else { fastqc = Channel.empty(); stast_illumina = Channel.empty() }
 
   if (params.illumina_single_end) { 
     clean_illumina_single(illumina_single_end_input_ch, prepare_host.out.host, prepare_host.out.checkedOwn, rRNAChannel)

--- a/configs/container.config
+++ b/configs/container.config
@@ -1,5 +1,6 @@
 process {
     withLabel: basics {     container = 'nanozoo/basics:1.0--9992be5' } 
+    withLabel: smallTask {  container = 'nanozoo/basics:1.0--9992be5' } 
     withLabel: minimap2 {   container = 'nanozoo/minimap2:2.18--618fb68' }
     withLabel: bbmap {      container = 'nanozoo/bbmap:38.79--8e915d7' } 
     withLabel: multiqc {    container = 'nanozoo/multiqc:1.9--aba729b' }

--- a/configs/container.config
+++ b/configs/container.config
@@ -1,6 +1,6 @@
 process {
     withLabel: basics {     container = 'nanozoo/basics:1.0--9992be5' } 
-    withLabel: smallTask {  container = 'nanozoo/basics:1.0--9992be5' } 
+    withLabel: smallTask {  container = 'nanozoo/samtools:1.14--d8fb865' } 
     withLabel: minimap2 {   container = 'nanozoo/minimap2:2.18--618fb68' }
     withLabel: bbmap {      container = 'nanozoo/bbmap:38.79--8e915d7' } 
     withLabel: multiqc {    container = 'nanozoo/multiqc:1.9--aba729b' }

--- a/configs/local.config
+++ b/configs/local.config
@@ -3,6 +3,7 @@ process {
     withLabel: minimap2 {   cpus = params.cores }
     withLabel: bbmap {      cpus = params.cores ; memory = params.memory  }
     withLabel: fastqc {     cpus = 2 }
+    withLabel: multiqc {    cpus = 2 }
     withLabel: nanoplot{    cpus = params.cores }
     withLabel: quast{       cpus = params.cores }
     withLabel: smallTask {  cpus = 1 }

--- a/configs/node.config
+++ b/configs/node.config
@@ -1,5 +1,5 @@
 process {
-    withLabel: basics {     cpus = 12;  memory = 8.GB } 
+    withLabel: basics {     cpus = 8;  memory = 8.GB } 
     withLabel: minimap2 {   cpus = 24;  memory = 24.GB }
     withLabel: bbmap {      cpus = 24;  memory = 24.GB }
     withLabel: smallTask {  cpus = 1;   memory = 2.GB }

--- a/configs/node.config
+++ b/configs/node.config
@@ -1,6 +1,9 @@
 process {
-    withLabel: basics {     cpus = 12;  memory = 4.GB } 
-    withLabel: minimap2 {   cpus = 24;  memory = 20.GB }
-    withLabel: bbmap {      cpus = 24;  memory = 30.GB }
+    withLabel: basics {     cpus = 12;  memory = 8.GB } 
+    withLabel: minimap2 {   cpus = 24;  memory = 24.GB }
+    withLabel: bbmap {      cpus = 24;  memory = 24.GB }
     withLabel: smallTask {  cpus = 1;   memory = 2.GB }
+    withLabel: fastqc {     cpus = 2;   memory = 4.GB }
+    withLabel: nanoplot{    cpus = 8;   memory = 8.GB }
+    withLabel: quast{       cpus = 8;   memory = 8.GB }
 }

--- a/configs/node.config
+++ b/configs/node.config
@@ -4,6 +4,7 @@ process {
     withLabel: bbmap {      cpus = 24;  memory = 24.GB }
     withLabel: smallTask {  cpus = 1;   memory = 2.GB }
     withLabel: fastqc {     cpus = 2;   memory = 4.GB }
+    withLabel: multiqc {    cpus = 4;   memory = 4.GB }
     withLabel: nanoplot{    cpus = 8;   memory = 8.GB }
     withLabel: quast{       cpus = 8;   memory = 8.GB }
 }

--- a/modules/get_host.nf
+++ b/modules/get_host.nf
@@ -85,7 +85,7 @@ process concat_contamination {
   
   script:
   """
-  cat * > db.fa.gz
+  cat *.gz > db.fa.gz
   samtools faidx db.fa.gz
   mv db.fa.gz.fai db.fa.fai
   """

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -74,8 +74,8 @@ process quast {
 
 process multiqc {
   label 'multiqc'
-  label 'smallTask'
-  
+ // label 'smallTask' // this is tricky for the cloud, because only one container can be mounted. Thus comment this as hot fix
+   
   publishDir "${params.output}/${params.multiqc_dir}", pattern: 'multiqc_report.html'
   
   input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -176,6 +176,13 @@ profiles {
         includeConfig 'configs/conda.config' 
     }
 
+    // cloud configs
+    node {
+        docker { enabled = true }
+        includeConfig 'configs/container.config'
+        includeConfig 'configs/node.config'
+    }
+
     // CONFIGURE YOUR PRIVATE CLOUD
     gcloud {             
         params.databases = 'gs://databases-matrice/databases/'


### PR DESCRIPTION
Hi @MarieLataretu , I wanted to run `clean` in the cloud to get rid of some mtDNA from new Chlamydia samples. I run into some small issues that are kinda cloud-specific and adjusted the code. 

Finally, the pipeline run through with the test

```
nextflow run hoelzer/clean -r update-node-config --nano ~/.nextflow/assets/hoelzer/clean/test/nanopore.fastq.gz --host eco --control dcs -profile cloud,node -c ~/nextflow-configs/cloud_profile.config -resume
```

except for the MultiQC step

```
[90/884e53] process > clean_nano:concat_contamination (1) [100%] 1 of 1, cached: 1 ✔
[c4/c4605a] process > clean_nano:minimap2_nano (1)        [100%] 1 of 1, cached: 1 ✔
[c0/f569dd] process > clean_nano:writeLog (1)             [100%] 1 of 1, cached: 1 ✔
[ac/ccf6fe] process > clean_nano:get_number_of_reads (1)  [100%] 1 of 1, cached: 1 ✔
[c1/619c6b] process > clean_nano:minimap2Stats (1)        [100%] 1 of 1, cached: 1 ✔
[a4/9b8fe4] process > clean_nano:compress_reads (2)       [100%] 2 of 2, cached: 2 ✔
[a9/d1bfa8] process > qc_nano:nanoplot (3)                [100%] 3 of 3, cached: 3 ✔
[b8/935462] process > qc_nano:format_nanoplot_report (3)  [100%] 3 of 3, cached: 3 ✔
[-        ] process > qc:multiqc    
```

I needed to update the 

```
fastqc = Channel.fromPath('no_illumina_input')
```

part to 

```
fastqc = Channel.empty()
```

because the problem in the cloud is, that `.fromPath` triggers staging of the file into the cloud. And of course there is not file `no_illumina_input` and the pipeline crashes. I think by passing empty channels I somehow destroy your logic for the MultiQC process and thus it is not even started : ) 