### PR TITLE
Fixes a few issues in the ML/issue55 branch

### DIFF
--- a/envs/multiqc.yaml
+++ b/envs/multiqc.yaml
@@ -2,5 +2,6 @@ name: multiqc
 channels:
   - bioconda
 dependencies:
+  - python<3.12.0
   - multiqc=1.12
   

--- a/envs/nanoplot.yaml
+++ b/envs/nanoplot.yaml
@@ -5,3 +5,5 @@ channels:
 dependencies:
   - nanoplot=1.32.1
   - seaborn==0.10.1
+  - matplotlib<3.6.0
+  - numpy<1.24.0

--- a/modules/alignment_processing.nf
+++ b/modules/alignment_processing.nf
@@ -150,7 +150,7 @@ process idxstats_from_bam {
   tuple val(name), val(type), path(bam), path(bai)
 
   output:
-  tuple val(name), val(type), path('*_idxstats.tsv')
+  tuple val(name), val(type), path('*.idxstats.tsv')
 
   script:
   """
@@ -165,13 +165,13 @@ process idxstats_from_bam {
 process flagstats_from_bam {
   label 'minimap2'
 
-  publishDir "${params.output}/minimap2", mode: params.publish_dir_mode, pattern: "${bam.baseName}_flagstats.txt" 
+  publishDir "${params.output}/minimap2", mode: params.publish_dir_mode, pattern: "${bam.baseName}.flagstats.txt"
 
   input:
   tuple val(name), val(type), path(bam), path(bai)
 
   output:
-  tuple val(name), val(type), path('*_flagstats.txt')
+  tuple val(name), val(type), path('*.flagstats.txt')
 
   script:
   """
@@ -195,7 +195,7 @@ process sort_bam {
   script:
   """
   mv ${bam} ${bam}.tmp
-  samtools sort -@ ${task.cpus} ${bam}.tmp > ${bam.baseName}.bam
+  samtools sort -@ ${task.cpus} ${bam}.tmp > ${bam.baseName}.sorted.bam
   """
   stub:
   """

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -64,7 +64,7 @@ process get_read_names {
 }
 
 process filter_fastq_by_name {
-  label 'basics'
+  label 'minimap2'  // We don't need minimap2 but the container has pigz
 
   if ( params.keep ) {
     publishDir "${params.output}/${params.tool}", mode: params.publish_dir_mode, pattern: "*.gz"


### PR DESCRIPTION
Resolves a couple little issues I ran into using the branch that includes work on the `--keep` functionality (see issue #55 ). What was fixed:

- process output file names don't always match the expected file name (mostly typo-type or missing suffix fixes)
- some conda envs are broken because of deprecations and removed code. Set maximum version numbers for a few packages to work around this.
- `filter_fastq_by_name` needs the `pigz` tool, but that was not available. For now I substituted the minimap2 container which happens to have pigz installed.